### PR TITLE
Fix swagger definition: remove trailing slash

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -106,7 +106,7 @@ paths:
                 host: 'tunnelx.webrelay.io'
         400:
           description: "Invalid tunnel request supplied"
-  /v1/tunnels/{tunnelID}/:
+  /v1/tunnels/{tunnelID}
     x-summary: Get, update and delete tunnels
     parameters:
       - name: "tunnelID"
@@ -258,7 +258,7 @@ paths:
               api_disabled: true
         400:
           description: ''
-  /v1/tokens/{tokenID}/: 
+  /v1/tokens/{tokenID} 
     x-summary: Update and delete tokens
     parameters:
       - name: "tokenID"
@@ -379,7 +379,7 @@ paths:
         400:
           description: "Invalid bucket request supplied"
   
-  /v1/buckets/{bucketID}/:
+  /v1/buckets/{bucketID}
     x-summary: Get and delete buckets
     parameters:
       - name: "bucketID"


### PR DESCRIPTION
Either swagger definition needs to be fixed, or server handling is wrong, because I'm getting HTML responses on queries with a slash.

Example:
```
<!DOCTYPE html><html><head><meta charset=utf-8><title>Webhook-Relay</title><meta name=viewport content="width=device-width,initial-scale=1"><link rel="shortcut icon" type=image/ico href=static/favicon.ico><link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons" rel=stylesheet type=text/css><script type=text/javascript>/* eslint-disable */
      window.$crisp=[];window.CRISP_WEBSITE_ID="80df233f-11f8-4810-8909-8f24f59d6342";(function(){d=document;s=d.createElement("script");s.src="https://client.crisp.chat/l.js";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();
      /* eslint-enable */</script><script src=https://js.stripe.com/v3/ ></script><script async src="https://www.googletagmanager.com/gtag/js?id=UA-91622498-3"></script><script>/* eslint-disable */
      window.dataLayer = window.dataLayer || []
      function gtag(){dataLayer.push(arguments);}
      gtag('js', new Date())

      gtag('config', 'UA-91622498-3', {'anonymize_ip': true})
      /* eslint-enable */</script><link href=/static/css/app.5d8e67a3d6d76a33f9b0e9008dc10354.css rel=stylesheet></head><body><div id=app></div><script type=text/javascript src=/static/js/manifest.c1c98411fa45152cc319.js></script><script type=text/javascript src=/static/js/vendor.3732861f9c29fa5e0855.js></script><script type=text/javascript src=/static/js/app.e7ff67016148048494f2.js></script></body></html>
```